### PR TITLE
build: include `crc32c_arm64.cc` when compiling for `aarch64`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -426,6 +426,18 @@ fn buildLibRocksDbStatic(
     });
 
     // platform dependent stuff
+    if (t.cpu.arch == .aarch64) {
+        librocksdb_a.addCSourceFile(.{
+            .file = rocks_dep.path("util/crc32c_arm64.cc"),
+            .flags = &.{
+                "-std=c++17",
+                "-faligned-new",
+                "-DHAVE_ALIGNED_NEW",
+                "-DROCKSDB_UBSAN_RUN",
+            },
+        });
+    }
+
     if (t.os.tag != .windows) {
         librocksdb_a.root_module.addCMacro("ROCKSDB_PLATFORM_POSIX", "");
         librocksdb_a.root_module.addCMacro("ROCKSDB_LIB_IO_POSIX", "");


### PR DESCRIPTION
No-one saw this because Zig 0.13 lacks M3 detection, so it was falling back to `generic` CPU model which lacks the `crc` feature. This meant this code path wasn't even being used. On M2 chips, we do have detection, so it would see the `crc` feature and try to link symbols in this file.

Occam's Razor strikes again.