### PR TITLE
cleanup the readme a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,56 @@
 Build and use RocksDB in zig.
 
-Supported use cases:
-- [⬇️](#build-rocksdb) Build a RocksDB static library using the zig build system.
-- [⬇️](#import-rocksdb-c-api-in-a-zig-project) Import RocksDB's C API as a normal zig dependency in a zig project.
-- [⬇️](#import-the-zig-bindings-library) Import an idiomatic zig library of bindings that wrap the RocksDB library with hand-written zig code.
+# Build Dependencies
 
-In all cases, RocksDB and all of its dependencies are statically linked. This offers portability because it works without needing to dynamically link to any shared libraries in the system.
+`rocksdb-zig` is pinned to [Zig `0.13`](https://ziglang.org/download/), so you will need to have it installed.
 
 # Usage
 
+Supported use cases:
+- [⬇️](#build-rocksdb) Build a RocksDB static library using the zig build system.
+- [⬇️](#import-rocksdb-c-api-in-a-zig-project) Use the RocksDB C API through auto-generated Zig bindings.
+- [⬇️](#import-the-zig-bindings-library) Import an idiomatic zig library of bindings that wrap the RocksDB library with hand-written zig code.
+
 ## Build RocksDB
-Clone this repository, then run `zig build`. The `zig-out` directory will contain the following:
-- include: folder containing all rocksdb header files
-- lib/librocksdb.a: statically linkable rocksdb binary containing all rocksdb dependencies.
+Clone this repository, then run `zig build`. 
 
-You can use these artifacts with any language or build system.
+You will find a statically linked `rocksdb` archive
+in `zig-out/lib/librocksdb.a`.
 
-## Import RocksDB C API in a Zig project
+You can use this with any language or build system.
 
-Add this to your dependencies in build.zig.zon:
-```zig
-.rocksdb = .{
-    .url = "https://github.com/Syndica/rocksdb-zig/archive/<COMMIT_HASH>.tar.gz",
-    .hash = "<TARBALL_HASH>",
-},
+## Import RocksDB C API in the Zig Build System.
+
+Fetch `rocksdb` and save it to your `build.zig.zon`:
+```
+$ zig fetch --save=rocksdb https://github.com/Syndica/rocksdb-zig/archive/<COMMIT_HASH>.tar.gz
 ```
 
-Add this to your build.zig:
+Add the import to a module:
 ```zig
 const rocksdb = b.dependency("rocksdb", .{}).module("rocksdb");
 exe.root_module.addImport("rocksdb", rocksdb);
 ```
 
-Add this to your zig program:
+Import the `rocksdb` module.
 ```zig
 const rocksdb = @import("rocksdb");
 ```
 
-## Import the Zig bindings library
+## Import the Zig bindings library using the Zig Build System.
 
-Add this to your dependencies in build.zig.zon:
-```zig
-.rocksdb = .{
-    .url = "https://github.com/Syndica/rocksdb-zig/archive/<COMMIT_HASH>.tar.gz",
-    .hash = "<TARBALL_HASH>",
-},
+Fetch `rocksdb` and save it to your `build.zig.zon`:
+```
+$ zig fetch --save=rocksdb https://github.com/Syndica/rocksdb-zig/archive/<COMMIT_HASH>.tar.gz
 ```
 
-Add this to your build.zig:
+Add the import to a module:
 ```zig
 const rocksdb_bindings = b.dependency("rocksdb", .{}).module("rocksdb-bindings");
 exe.root_module.addImport("rocksdb-bindings", rocksdb_bindings);
 ```
 
-Add this to your zig program:
+Import the `rocksdb-bindings` module.
 ```zig
 const rocksdb = @import("rocksdb-bindings");
 ```
-
-# Build Dependencies
-must be in PATH:
-- make
-- zig
-
-Currently this works by having Zig call out to the RocksDB build system under the hood. In the future, I'd like to replace this with zig as the entire build system. For now, you'll need make installed. This configures make to use zig as the c and c++ compiler, so you don't need any other c compiler installed, but this is why you do need zig in your PATH.


### PR DESCRIPTION
Just wanted to cleanup the README a bit. 
- Removed the stale paragraph about needing `make` and `zig` in your path, (you technically don't need it to be called `zig` now).
- Show how to fetch the dependency the intended way, instead of finding out the hash through the error message.
- Clarified some wording.