### PR TITLE
fix rwlock requires non const

### DIFF
--- a/src/database.zig
+++ b/src/database.zig
@@ -429,7 +429,7 @@ const CfNameToHandleMap = struct {
         self.map.put(self.allocator, owned_name, handle);
     }
 
-    fn get(self: *const Self, name: []const u8) ?ColumnFamilyHandle {
+    fn get(self: *Self, name: []const u8) ?ColumnFamilyHandle {
         self.lock.lockShared();
         defer self.lock.unlockShared();
         return self.map.get(name);


### PR DESCRIPTION
this fixes:

```
/Users/aep/.cache/zig/p/122086b7931284e391223ce165a9bee94b624a7fb34531ecc95cafb22f049887d175/src/database.zig:433:18: error: expected type '*Thread.RwLock', found '*const Thread.RwLock'
        self.lock.lockShared();
        ~~~~~~~~~^~~~~~~~~~~
/Users/aep/.cache/zig/p/122086b7931284e391223ce165a9bee94b624a7fb34531ecc95cafb22f049887d175/src/database.zig:433:18: note: cast discards const qualifier
/Users/aep/zig/0.13.0/files/lib/std/Thread/RwLock.zig:47:24: note: parameter type declared here
pub fn lockShared(rwl: *RwLock) void {
                       ^~~~~~~
referenced by:
    columnFamily: /Users/aep/.cache/zig/p/122086b7931284e391223ce165a9bee94b624a7fb34531ecc95cafb22f049887d175/src/database.zig:124:38
    main: src/main.zig:30:26
    remaining reference traces hidden; use '-freference-trace' to see all reference traces
```